### PR TITLE
Various bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ iex> Easing.sine_in(0.4)
 However you likely want to calculate the list of values for a given animation. `Easing.to_list/2` will take a `Easing.AnimationRange` struct and the easing as either a function reference or a tuple.
 
 ```elixir
-iex> Easing.to_list(%Easing.AnimationRange{first: 0, last: 1, step: 0.1}, &Easing.bounce_in_out(&1))
-[0.030000000000000027, 0.11375000000000002, 0.04499999999999993, 0.3487500000000001, 0.5]
+iex> Easing.to_list(%Easing.AnimationRange{first: 0, last: 0.5, step: 0.1}, &Easing.bounce_in_out(&1))
+[0.0, 0.030000000000000027, 0.11375000000000002, 0.04499999999999993, 0.3487500000000001, 0.5]
 iex> Easing.to_list(%Easing.AnimationRange{first: 0, last: 0.5, step: 0.1}, {:bounce, :in_out})
-[0.030000000000000027, 0.11375000000000002, 0.04499999999999993, 0.3487500000000001, 0.5]
+[0.0, 0.030000000000000027, 0.11375000000000002, 0.04499999999999993, 0.3487500000000001, 0.5]
 ```
 
 ### Calculating animation frames from a Stream
@@ -67,7 +67,7 @@ In many cases you will generate many animation frame values and it may be most p
 
 ```elixir
 iex> Easing.stream(%Easing.AnimationRange{first: 0, last: 1, step: 0.0001}, &Easing.sine_in/1) |> Enum.take(3)
-[0, 1.2337005528273437e-8, 4.9348021557982236e-8]
+[0.0, 1.2337005528273437e-8, 4.9348021557982236e-8]
 ```
 
 `Easing.stream/2` also take a `tuple` similar to `Easing.to_list/2`
@@ -88,7 +88,7 @@ end
 iex> Easing.to_list(Easing.AnimationRange.new(0, 1, 0.1), custom_easing)
 [0.0, 0.006155829702431115, 0.024471741852423234, 0.054496737905816106,
  0.09549150281252627, 0.8535533905932737, 0.7938926261462367,
- 0.7269952498697734, 0.6545084971874737, 0.5782172325201156, 0.5000000000000002]
+ 0.7269952498697734, 0.6545084971874737, 0.5782172325201156, 0.5]
 ```
 
 ### `Easing.AnimationRange`

--- a/lib/easing.ex
+++ b/lib/easing.ex
@@ -23,10 +23,10 @@ defmodule Easing do
   ## Examples:
 
       iex> Easing.to_list(%Easing.AnimationRange{first: 0, last: 1, step: 0.1}, &Easing.sine_in(&1))
-      [0, 0.01231165940486223, 0.04894348370484647, 0.10899347581163221, 0.19098300562505255, 0.2928932188134524, 0.41221474770752675, 0.5460095002604533, 0.6909830056250525, 0.8435655349597688, 0.9999999999999997]
+      [0.0, 0.01231165940486223, 0.04894348370484647, 0.10899347581163221, 0.19098300562505255, 0.2928932188134524, 0.41221474770752675, 0.5460095002604533, 0.6909830056250525, 0.8435655349597688, 1.0]
 
       iex> Easing.to_list(%Easing.AnimationRange{first: 0, last: 0.5, step: 0.1}, {:bounce, :in_out})
-      [0, 0.030000000000000027, 0.11375000000000002, 0.04499999999999993, 0.3487500000000001, 0.5]
+      [0.0, 0.030000000000000027, 0.11375000000000002, 0.04499999999999993, 0.3487500000000001, 0.5]
   """
   def to_list(%AnimationRange{} = animation_range, easing) do
     animation_range
@@ -34,7 +34,7 @@ defmodule Easing do
     |> Enum.to_list()
   end
 
-  @spec to_list(animation_range(), easing_function_or_tuple()) :: easings()
+  @spec stream(animation_range(), easing_function_or_tuple()) :: Enumerable.t()
   @doc """
   Generates a stream of animation frame values.
 
@@ -42,10 +42,10 @@ defmodule Easing do
 
   ## Examples:
       iex> Easing.stream(%Easing.AnimationRange{first: 0, last: 1, step: 0.1}, &Easing.sine_in(&1)) |> Enum.to_list()
-      [0, 0.01231165940486223, 0.04894348370484647, 0.10899347581163221, 0.19098300562505255, 0.2928932188134524, 0.41221474770752675, 0.5460095002604533, 0.6909830056250525, 0.8435655349597688, 0.9999999999999997]
+      [0.0, 0.01231165940486223, 0.04894348370484647, 0.10899347581163221, 0.19098300562505255, 0.2928932188134524, 0.41221474770752675, 0.5460095002604533, 0.6909830056250525, 0.8435655349597688, 1.0]
 
       iex> Easing.stream(%Easing.AnimationRange{first: 0, last: 0.5, step: 0.1}, {:bounce, :in_out}) |> Enum.to_list()
-      [0, 0.030000000000000027, 0.11375000000000002, 0.04499999999999993, 0.3487500000000001, 0.5]
+      [0.0, 0.030000000000000027, 0.11375000000000002, 0.04499999999999993, 0.3487500000000001, 0.5]
 
   """
   def stream(%AnimationRange{} = animation_range, easing_function) when is_function(easing_function) do
@@ -478,7 +478,7 @@ defmodule Easing do
   """
   def bounce_in_out(progress), do: run({:bounce, :in_out}, progress)
 
-  @spec run(easing_function(), float()) :: float()
+  @spec run(easing_function_or_tuple(), float()) :: float()
   @doc """
   Easing calculation. Take a tupal of atoms `{direction, type}` and the progress is a value
   between 0 - 1 that represents the animation progress. (0 = beginning, 1 = end)
@@ -491,8 +491,8 @@ defmodule Easing do
   """
   def run(easing_function, progress) do
     cond do
-      progress == 0 -> 0
-      progress == 1 -> 1
+      progress == 0 -> 0.0
+      progress == 1 -> 1.0
       true -> do_run(easing_function, progress)
     end
   end
@@ -675,7 +675,7 @@ defmodule Easing do
   # Bounce
 
   defp do_run({:bounce, :in}, progress) do
-    1 - run({:bounce, :out}, 1 - progress)
+    1.0 - run({:bounce, :out}, 1.0 - progress)
   end
 
   defp do_run({:bounce, :out}, progress) do

--- a/lib/easing/animation_range.ex
+++ b/lib/easing/animation_range.ex
@@ -66,14 +66,14 @@ defmodule Easing.AnimationRange do
       {:suspended, acc, &reduce(first, last, &1, fun, step)}
     end
 
-    defp reduce(first, last, {:cont, acc}, fun, step)
-         when step > 0 and first <= last
-         when step < 0 and first >= last do
-      reduce(first + step, last, fun.(first, acc), fun, step)
-    end
-
-    defp reduce(_, _, {:cont, acc}, _fun, _up) do
-      {:done, acc}
+    defp reduce(first, last, {:cont, acc}, fun, step) do
+      cond do
+        Float.ceil(first + 0.0, 10) >= last ->
+          {_, acc} = fun.(last, acc)
+          {:done, acc}
+        true ->
+          reduce(first + step, last, fun.(first, acc), fun, step)
+      end
     end
 
     def member?(%{__struct__: Easing.AnimationRange, first: first, last: last, step: step} = range, value) do

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Easing.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       consolidate_protocols: Mix.env() != :test,
       package: package(),
-      description: (),
+      description: description(),
       source_url: @scm_url,
       docs: docs(),
       deps: deps()

--- a/test/easing/animation_range_test.exs
+++ b/test/easing/animation_range_test.exs
@@ -1,4 +1,15 @@
 defmodule Easing.AnimationRangeTest do
   use ExUnit.Case
   doctest Easing.AnimationRange
+  alias Easing.AnimationRange
+
+  test "animation range produces full range of values" do
+    range = %AnimationRange{first: 0, last: 1, step: 0.1}
+
+    list = Enum.to_list(range)
+
+    assert length(list) == 11
+    assert Enum.at(list, 0) == 0.0
+    assert Enum.at(list, length(list) - 1) == 1.0
+  end
 end


### PR DESCRIPTION
* resolved Dialyzer complaints
* ensured that all values returned are of type `Float`
* ensured that the range of values with `Easing.to_list/2` and `Easing.stream/2` always include the `first` and `last` values rather than near approximations
* fixed missing `description` in the package
* updated README to reflect new return values